### PR TITLE
Fix typo in readme text

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func main() {
     // Updated user data should now be:
     // User{
     //     ID:         "1",
-    //     Name:       "Johnny",
+    //     Name:       "Johnson",
     //     Age:        21,
     //     DeletedAt:  nil,
     // }


### PR DESCRIPTION
Although it's just a typo, it might create confusion while skimming through the readme to get basic understanding of working of the package